### PR TITLE
Add support for Semaphore CI

### DIFF
--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -21,6 +21,7 @@ module Percy
         return :circle if ENV['CIRCLECI']
         return :codeship if ENV['CI_NAME'] && ENV['CI_NAME'] == 'codeship'
         return :drone if ENV['DRONE'] == 'true'
+        return :semaphore if ENV['SEMAPHORE'] == 'true'
       end
 
       # @return [Hash] All commit data from the current commit. Might be empty if commit data could
@@ -68,6 +69,8 @@ module Percy
           ENV['CI_COMMIT_ID']
         when :drone
           ENV['DRONE_COMMIT']
+        when :semaphore
+          ENV['REVISION']
         end
       end
 
@@ -94,6 +97,8 @@ module Percy
           ENV['CI_BRANCH']
         when :drone
           ENV['DRONE_BRANCH']
+        when :semaphore
+          ENV['BRANCH_NAME']
         else
           _raw_branch_output
         end
@@ -119,6 +124,8 @@ module Percy
           ENV['TRAVIS_REPO_SLUG']
         when :circle
           "#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}"
+        when :semaphore
+          ENV['SEMAPHORE_REPO_SLUG']
         else
           origin_url = _get_origin_url.strip
           if origin_url == ''
@@ -153,6 +160,8 @@ module Percy
           # Unfortunately, codeship always returns 'false' for CI_PULL_REQUEST. For now, return nil.
         when :drone
           ENV['CI_PULL_REQUEST']
+        when :semaphore
+          ENV['PULL_REQUEST_NUMBER']
         end
       end
 
@@ -166,6 +175,8 @@ module Percy
           ENV['CIRCLE_BUILD_NUM']
         when :travis
           ENV['TRAVIS_BUILD_NUMBER']
+        when :semaphore
+          ENV['SEMAPHORE_BUILD_NUMBER']
         end
       end
 
@@ -180,6 +191,8 @@ module Percy
           # Support for https://github.com/ArturT/knapsack
           var = 'CI_NODE_TOTAL'
           Integer(ENV[var]) if ENV[var] && !ENV[var].empty?
+        when :semaphore
+          Integer(ENV['SEMAPHORE_THREAD_COUNT'])
         end
       end
 

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Percy::Client::Environment do
     ENV['DRONE_COMMIT'] = nil
     ENV['DRONE_BRANCH'] = nil
     ENV['CI_PULL_REQUEST'] = nil
+
+    # Unset Semaphore CI vars
+    ENV['CI'] = nil
+    ENV['SEMAPHORE'] = nil
+    ENV['REVISION'] = nil
+    ENV['BRANCH_NAME'] = nil
+    ENV['SEMAPHORE_REPO_SLUG'] = nil
+    ENV['SEMAPHORE_BUILD_NUMBER'] = nil
+    ENV['SEMAPHORE_CURRENT_THREAD'] = nil
+    ENV['PULL_REQUEST_NUMBER'] = nil
   end
 
   before(:each) do
@@ -368,6 +378,54 @@ RSpec.describe Percy::Client::Environment do
     describe '#repo' do
       it 'returns the current local repo name' do
         expect(Percy::Client::Environment.repo).to eq('percy/percy-client')
+      end
+    end
+  end
+  context 'in Semaphoe CI' do
+    before(:each) do
+      ENV['SEMAPHORE'] = 'true'
+      ENV['BRANCH_NAME'] = 'semaphore-branch'
+      ENV['REVISION'] = 'semaphore-commit-sha'
+      ENV['SEMAPHORE_REPO_SLUG'] = 'repo-owner/repo-name'
+      ENV['SEMAPHORE_BUILD_NUMBER'] = 'semaphore-build-number'
+      ENV['SEMAPHORE_THREAD_COUNT'] = '2'
+      ENV['PULL_REQUEST_NUMBER'] = '123'
+    end
+
+    describe '#current_ci' do
+      it 'is :semaphore' do
+        expect(Percy::Client::Environment.current_ci).to eq(:semaphore)
+      end
+    end
+    describe '#branch' do
+      it 'reads from the CI environment' do
+        expect(Percy::Client::Environment.branch).to eq('semaphore-branch')
+      end
+    end
+    describe '#_commit_sha' do
+      it 'reads from the CI environment' do
+        expect(Percy::Client::Environment._commit_sha).to eq('semaphore-commit-sha')
+      end
+    end
+
+    describe '#pull_request_number' do
+      it 'reads from the CI environment' do
+        expect(Percy::Client::Environment.pull_request_number).to eq('123')
+      end
+    end
+    describe '#repo' do
+      it 'reads from the CI environment' do
+        expect(Percy::Client::Environment.repo).to eq('repo-owner/repo-name')
+      end
+    end
+    describe '#parallel_nonce' do
+      it 'reads from the CI environment (the CI build number)' do
+        expect(Percy::Client::Environment.parallel_nonce).to eq('semaphore-build-number')
+      end
+    end
+    describe '#parallel_total_shards' do
+      it 'reads from the CI environment (the number of nodes)' do
+        expect(Percy::Client::Environment.parallel_total_shards).to eq(2)
       end
     end
   end


### PR DESCRIPTION
Allows Percy to be run from [Semaphore CI](https://semaphoreci.com).

Note: The Semaphore environment variables are documented at https://semaphoreci.com/docs/available-environment-variables.html