### PR TITLE
URI.escape logs obsolete warnings, use Addressable instead.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     percy-client (1.9.0)
+      addressable
       faraday (>= 0.9)
       httpclient (>= 2.6)
 
@@ -34,7 +35,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hitimes (1.2.2)
-    httpclient (2.8.2.4)
+    httpclient (2.8.3)
     listen (2.10.0)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -91,4 +92,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/lib/percy/client/resources.rb
+++ b/lib/percy/client/resources.rb
@@ -1,6 +1,6 @@
 require 'base64'
 require 'digest'
-require 'uri'
+require 'addressable/uri'
 
 module Percy
   class Client
@@ -37,7 +37,7 @@ module Percy
           'type' => 'resources',
           'id' => sha,
           'attributes' => {
-            'resource-url' => URI.escape(resource_url),
+            'resource-url' => Addressable::URI.escape(resource_url),
             'mimetype' => mimetype,
             'is-root' => is_root,
           },

--- a/percy-client.gemspec
+++ b/percy-client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '>= 0.9'
   spec.add_dependency 'httpclient', '>= 2.6'
+  spec.add_dependency 'addressable'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This fixes many log lines that show `serialize: warning: URI.escape is obsolete`.

More information here: http://ashwinbalaguru.blogspot.com/2016/03/the-difference-between-uriescape-and.html