### PR TITLE
Fix warnings with methods being defined twice

### DIFF
--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -36,7 +36,7 @@ module Percy
 
         # If not running in a git repo, allow nils for certain commit attributes.
         extract_or_nil = lambda { |regex| (output && output.match(regex) || [])[1] }
-        data = {
+        return {
           # The only required attribute:
           branch: branch,
           # An optional but important attribute:

--- a/lib/percy/config.rb
+++ b/lib/percy/config.rb
@@ -11,11 +11,11 @@ module Percy
     # @!attribute default_widths
     #   @return [Array] List of default widths for snapshot rendering unless overridden.
 
-    attr_accessor :access_token
-    attr_accessor :api_url
-    attr_accessor :debug
-    attr_accessor :repo
-    attr_accessor :default_widths
+    attr_writer :access_token
+    attr_writer :api_url
+    attr_writer :debug
+    attr_writer :repo
+    attr_writer :default_widths
 
     # List of configurable keys for {Percy::Client}
     # @return [Array] Option keys.


### PR DESCRIPTION
i.e. `warning: method redefined; discarding old access_token`