### PR TITLE
implement equality operators on resource

### DIFF
--- a/lib/percy/client/resources.rb
+++ b/lib/percy/client/resources.rb
@@ -43,6 +43,21 @@ module Percy
         }
       end
 
+      def ==(other)
+        other.is_a?(self.class) &&
+          other.sha == sha &&
+          other.resource_url == resource_url &&
+          other.mimetype == mimetype
+      end
+
+      def hash
+        [sha, resource_url, mimetype].hash
+      end
+
+      def eql?(other)
+        self == other && hash == other.hash
+      end
+
       def inspect
         content_msg = content.nil? ? '' : "content.length: #{content.length}"
         "<Resource #{sha} #{resource_url} is_root:#{!!is_root} #{mimetype} #{content_msg}>"

--- a/spec/lib/percy/client/resources_spec.rb
+++ b/spec/lib/percy/client/resources_spec.rb
@@ -1,88 +1,9 @@
 require 'digest'
 
+# rubocop:disable RSpec/MultipleDescribes
 RSpec.describe Percy::Client::Resources, :vcr do
   let(:content) { "hello world! #{described_class.name}" }
   let(:sha) { Digest::SHA256.hexdigest(content) }
-
-  describe 'Percy::Client::Resource' do
-    it 'can be initialized with minimal data' do
-      resource = Percy::Client::Resource.new('/foo.html', sha: sha)
-      expect(resource.serialize).to eq(
-        'type' => 'resources',
-        'id' => sha,
-        'attributes' => {
-          'resource-url' => '/foo.html',
-          'mimetype' => nil,
-          'is-root' => nil,
-        },
-      )
-    end
-    it 'can be initialized with all data' do
-      resource = Percy::Client::Resource.new(
-        '/foo new.html',
-        sha: sha,
-        is_root: true,
-        mimetype: 'text/html',
-        content: content,
-      )
-      expect(resource.serialize).to eq(
-        'type' => 'resources',
-        'id' => sha,
-        'attributes' => {
-          'resource-url' => '/foo%20new.html',
-          'mimetype' => 'text/html',
-          'is-root' => true,
-        },
-      )
-    end
-    it 'errors if not given sha or content' do
-      expect { Percy::Client::Resource.new('/foo.html') }.to raise_error(ArgumentError)
-    end
-
-    describe 'two resources with same properties' do
-      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
-
-      let(:other) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
-
-      it { is_expected.to eq(other) }
-      it { is_expected.to eql(other) }
-      it { expect(resource.hash).to eq(other.hash) }
-      it('makes their array unique') { expect([resource, other].uniq).to eq([resource]) }
-    end
-
-    describe 'two resources with different sha' do
-      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
-
-      let(:other) { Percy::Client::Resource.new('/some-content', sha: '654321', mimetype: 'text/plain') }
-
-      it { is_expected.not_to eq(other) }
-      it { is_expected.not_to eql(other) }
-      it { expect(resource.hash).not_to eq(other.hash) }
-      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
-    end
-
-    describe 'two resources with different url' do
-      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
-
-      let(:other) { Percy::Client::Resource.new('/different-content', sha: '123456', mimetype: 'text/plain') }
-
-      it { is_expected.not_to eq(other) }
-      it { is_expected.not_to eql(other) }
-      it { expect(resource.hash).not_to eq(other.hash) }
-      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
-    end
-
-    describe 'two resources with different mimetype' do
-      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
-
-      let(:other) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/x-plain') }
-
-      it { is_expected.not_to eq(other) }
-      it { is_expected.not_to eql(other) }
-      it { expect(resource.hash).not_to eq(other.hash) }
-      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
-    end
-  end
 
   describe '#upload_resource' do
     it 'returns true with success' do
@@ -93,6 +14,88 @@ RSpec.describe Percy::Client::Resources, :vcr do
       # Verify that upload_resource hides conflict errors, though they are output to stderr.
       expect(Percy.upload_resource(build['data']['id'], content)).to be_truthy
       expect(Percy.upload_resource(build['data']['id'], content)).to be_truthy
+    end
+  end
+end
+
+RSpec.describe Percy::Client::Resource do
+  let(:content) { "hello world! #{described_class.name}" }
+  let(:sha) { Digest::SHA256.hexdigest(content) }
+
+  it 'can be initialized with minimal data' do
+    resource = described_class.new('/foo.html', sha: sha)
+    expect(resource.serialize).to eq(
+      'type' => 'resources',
+      'id' => sha,
+      'attributes' => {
+        'resource-url' => '/foo.html',
+        'mimetype' => nil,
+        'is-root' => nil,
+      },
+    )
+  end
+  it 'can be initialized with all data' do
+    resource = described_class.new(
+      '/foo new.html',
+      sha: sha,
+      is_root: true,
+      mimetype: 'text/html',
+      content: content,
+    )
+    expect(resource.serialize).to eq(
+      'type' => 'resources',
+      'id' => sha,
+      'attributes' => {
+        'resource-url' => '/foo%20new.html',
+        'mimetype' => 'text/html',
+        'is-root' => true,
+      },
+    )
+  end
+  it 'errors if not given sha or content' do
+    expect { described_class.new('/foo.html') }.to raise_error(ArgumentError)
+  end
+
+  describe 'object equality' do
+    subject(:resource) { described_class.new('/some-content', sha: sha, mimetype: mimetype) }
+
+    let(:sha) { '123456' }
+    let(:mimetype) { 'text/plain' }
+
+    describe 'two resources with same properties' do
+      let(:other) { described_class.new('/some-content', sha: sha, mimetype: mimetype) }
+
+      it { is_expected.to eq(other) }
+      it { is_expected.to eql(other) }
+      it { expect(resource.hash).to eq(other.hash) }
+      it('makes their array unique') { expect([resource, other].uniq).to eq([resource]) }
+    end
+
+    describe 'two resources with different sha' do
+      let(:other) { described_class.new('/some-content', sha: sha.reverse, mimetype: mimetype) }
+
+      it { is_expected.not_to eq(other) }
+      it { is_expected.not_to eql(other) }
+      it { expect(resource.hash).not_to eq(other.hash) }
+      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
+    end
+
+    describe 'two resources with different url' do
+      let(:other) { described_class.new('/different-content', sha: sha, mimetype: mimetype) }
+
+      it { is_expected.not_to eq(other) }
+      it { is_expected.not_to eql(other) }
+      it { expect(resource.hash).not_to eq(other.hash) }
+      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
+    end
+
+    describe 'two resources with different mimetype' do
+      let(:other) { described_class.new('/some-content', sha: sha, mimetype: 'text/css') }
+
+      it { is_expected.not_to eq(other) }
+      it { is_expected.not_to eql(other) }
+      it { expect(resource.hash).not_to eq(other.hash) }
+      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
     end
   end
 end

--- a/spec/lib/percy/client/resources_spec.rb
+++ b/spec/lib/percy/client/resources_spec.rb
@@ -38,7 +38,52 @@ RSpec.describe Percy::Client::Resources, :vcr do
     it 'errors if not given sha or content' do
       expect { Percy::Client::Resource.new('/foo.html') }.to raise_error(ArgumentError)
     end
+
+    describe 'two resources with same properties' do
+      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
+
+      let(:other) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
+
+      it { is_expected.to eq(other) }
+      it { is_expected.to eql(other) }
+      it { expect(resource.hash).to eq(other.hash) }
+      it('makes their array unique') { expect([resource, other].uniq).to eq([resource]) }
+    end
+
+    describe 'two resources with different sha' do
+      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
+
+      let(:other) { Percy::Client::Resource.new('/some-content', sha: '654321', mimetype: 'text/plain') }
+
+      it { is_expected.not_to eq(other) }
+      it { is_expected.not_to eql(other) }
+      it { expect(resource.hash).not_to eq(other.hash) }
+      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
+    end
+
+    describe 'two resources with different url' do
+      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
+
+      let(:other) { Percy::Client::Resource.new('/different-content', sha: '123456', mimetype: 'text/plain') }
+
+      it { is_expected.not_to eq(other) }
+      it { is_expected.not_to eql(other) }
+      it { expect(resource.hash).not_to eq(other.hash) }
+      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
+    end
+
+    describe 'two resources with different mimetype' do
+      subject(:resource) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/plain') }
+
+      let(:other) { Percy::Client::Resource.new('/some-content', sha: '123456', mimetype: 'text/x-plain') }
+
+      it { is_expected.not_to eq(other) }
+      it { is_expected.not_to eql(other) }
+      it { expect(resource.hash).not_to eq(other.hash) }
+      it('makes array unique') { expect([resource, other].uniq).to eq([resource, other]) }
+    end
   end
+
   describe '#upload_resource' do
     it 'returns true with success' do
       build = Percy.create_build('fotinakis/percy-examples')


### PR DESCRIPTION
this is useful to make their array unique
because the API does not accept duplicated resources

issued PR to percy-capybara native loader to use this to de-duplicate resources uploaded to the API: https://github.com/percy/percy-capybara/pull/33