### PR TITLE
feat: add BUILDKITE_PARALLEL_JOB_COUNT for PERCY_PARALLEL_TOTAL

### DIFF
--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -232,6 +232,9 @@ module Percy
         when :semaphore
           var = 'SEMAPHORE_THREAD_COUNT'
           Integer(ENV[var]) if ENV[var] && !ENV[var].empty?
+        when :buildkite
+          var = 'BUILDKITE_PARALLEL_JOB_COUNT'
+          Integer(ENV[var]) if ENV[var] && !ENV[var].empty?
         end
       end
 


### PR DESCRIPTION
This makes Percy aware of parallel buildkite runs using `BUILDKITE_PARALLEL_JOB_COUNT` as `PERCY_PARALLEL_TOTAL` default.