### PR TITLE
Add user agent support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ gemspec
 
 gem 'guard-rspec', require: false
 
+group :test, :development do
+  gem 'pry'
+end
+
 group :test do
   gem 'rubocop'
   gem 'rubocop-rspec'

--- a/lib/percy.rb
+++ b/lib/percy.rb
@@ -15,8 +15,15 @@ module Percy
   # API client based on configured options.
   #
   # @return [Percy::Client] API client.
-  def self.client
-    @client = Percy::Client.new(config: config) if !defined?(@client) || !@client
+  def self.client(options = {})
+    if !defined?(@client) || !@client
+      @client = Percy::Client.new(
+        config: config,
+        client_info: options[:client_info],
+        environment_info: options[:environment_info],
+      )
+    end
+
     @client
   end
 

--- a/lib/percy/client.rb
+++ b/lib/percy/client.rb
@@ -45,10 +45,12 @@ module Percy
     class BadGatewayError < ServerError; end # 502.
     class ServiceUnavailableError < ServerError; end # 503.
 
-    attr_reader :config
+    attr_reader :config, :client_info, :environment_info
 
     def initialize(options = {})
       @config = options[:config] || Percy::Config.new
+      @client_info = options[:client_info]
+      @environment_info = options[:environment_info]
     end
   end
 end

--- a/lib/percy/client/builds.rb
+++ b/lib/percy/client/builds.rb
@@ -14,6 +14,7 @@ module Percy
         # Only pass parallelism data if it all exists and there is more than 1 shard.
         in_parallel_environment = parallel_nonce && \
           parallel_total_shards && parallel_total_shards > 1
+
         unless in_parallel_environment
           parallel_nonce = nil
           parallel_total_shards = nil
@@ -44,6 +45,7 @@ module Percy
             raise ArgumentError,
               'resources argument must be an iterable of Percy::Client::Resource objects'
           end
+
           relationships_data = {
             'relationships' => {
               'resources' => {
@@ -51,16 +53,19 @@ module Percy
               },
             },
           }
+
           data['data'].merge!(relationships_data)
         end
 
         build_data = post("#{config.api_url}/repos/#{repo}/builds/", data)
         Percy.logger.debug { "Build #{build_data['data']['id']} created" }
+
         parallelism_msg = if parallel_total_shards
           "#{parallel_total_shards} shards detected (nonce: #{parallel_nonce.inspect})"
         else
           'not detected'
         end
+
         Percy.logger.debug { "Parallel test environment: #{parallelism_msg}" }
         build_data
       end

--- a/lib/percy/client/connection.rb
+++ b/lib/percy/client/connection.rb
@@ -20,6 +20,7 @@ module Percy
 
         def on_complete(env)
           error_class = nil
+
           case env[:status]
           when 400
             error_class = Percy::Client::BadRequestError
@@ -42,7 +43,9 @@ module Percy
           when CLIENT_ERROR_STATUS_RANGE # Catchall.
             error_class = Percy::Client::HttpError
           end
+
           return unless error_class
+
           raise error_class.new(
             env.status, env.method.upcase, env.url, env.body,
             "Got #{env.status} (#{env.method.upcase} #{env.url}):\n#{env.body}",
@@ -52,23 +55,27 @@ module Percy
 
       def connection
         return @connection if defined?(@connection)
+
         parsed_uri = URI.parse(config.api_url)
         base_url = "#{parsed_uri.scheme}://#{parsed_uri.host}:#{parsed_uri.port}"
+
         @connection = Faraday.new(url: base_url) do |faraday|
           faraday.request :token_auth, config.access_token if config.access_token
 
           faraday.use Percy::Client::Connection::NoCookiesHTTPClientAdapter
           faraday.use Percy::Client::Connection::NiceErrorMiddleware
         end
+
         @connection
       end
 
       def get(path, options = {})
         retries = options[:retries] || 3
+
         begin
           response = connection.get do |request|
             request.url(path)
-            request.headers['Content-Type'] = 'application/vnd.api+json'
+            request.headers.merge! _headers
           end
         rescue Faraday::TimeoutError
           raise Percy::Client::TimeoutError
@@ -87,10 +94,11 @@ module Percy
 
       def post(path, data, options = {})
         retries = options[:retries] || 3
+
         begin
           response = connection.post do |request|
             request.url(path)
-            request.headers['Content-Type'] = 'application/vnd.api+json'
+            request.headers.merge! _headers
             request.body = data.to_json
           end
         rescue Faraday::TimeoutError
@@ -102,9 +110,42 @@ module Percy
             sleep(rand(1..3))
             retry
           end
+
           raise e
         end
+
         JSON.parse(response.body)
+      end
+
+      def _headers
+        {
+          'Content-Type' => 'application/vnd.api+json',
+          'User-Agent' => _user_agent,
+        }
+      end
+
+      def _user_agent
+        client = [
+          "Percy/#{_api_version}",
+          client_info,
+          "percy-client/#{VERSION}",
+        ].compact.join(' ')
+
+        environment = [
+          environment_info,
+          "ruby/#{_ruby_version}",
+          Percy::Client::Environment.current_ci,
+        ].compact.join('; ')
+
+        "#{client} (#{environment})"
+      end
+
+      def _api_version
+        config.api_url.match(/\w+$/).to_s
+      end
+
+      def _ruby_version
+        "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
       end
     end
   end

--- a/lib/percy/client/connection.rb
+++ b/lib/percy/client/connection.rb
@@ -125,19 +125,25 @@ module Percy
       end
 
       def _user_agent
-        client = [
-          "Percy/#{_api_version}",
-          client_info,
-          "percy-client/#{VERSION}",
-        ].compact.join(' ')
+        @_user_agent ||= begin
+          client = [
+            "Percy/#{_api_version}",
+            client_info,
+            "percy-client/#{VERSION}",
+          ].compact.join(' ')
 
-        environment = [
-          environment_info,
-          "ruby/#{_ruby_version}",
-          Percy::Client::Environment.current_ci,
-        ].compact.join('; ')
+          environment = [
+            environment_info,
+            "ruby/#{_ruby_version}",
+            Percy::Client::Environment.current_ci,
+          ].compact.join('; ')
 
-        "#{client} (#{environment})"
+          "#{client} (#{environment})"
+        end
+      end
+
+      def _reset_user_agent
+        @_user_agent = nil
       end
 
       def _api_version

--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -26,6 +26,22 @@ module Percy
         return :gitlab if ENV['GITLAB_CI']
       end
 
+      def self.user_agent(client_info: nil, environment_info: nil)
+        client = [
+          "Percy/#{_api_version}",
+          client_info,
+          "percy-client/#{VERSION}",
+        ].compact.join(' ')
+
+        environment = [
+          environment_info,
+          "ruby/#{_ruby_version}",
+          current_ci,
+        ].compact.join('; ')
+
+        "#{client} (#{environment})"
+      end
+
       # @return [Hash] All commit data from the current commit. Might be empty if commit data could
       # not be found.
       def self.commit
@@ -92,6 +108,14 @@ module Percy
         output = `git show --quiet #{commit_sha} --format="#{format}" 2> /dev/null`.strip
         return if $CHILD_STATUS.to_i != 0
         output
+      end
+
+      def self._ruby_version
+        "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
+      end
+
+      def self._api_version
+        Config.new.api_url.match(/\w+$/).to_s
       end
 
       # The name of the current branch.

--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -26,21 +26,7 @@ module Percy
         return :gitlab if ENV['GITLAB_CI']
       end
 
-      def self.user_agent(client_info: nil, environment_info: nil)
-        client = [
-          "Percy/#{_api_version}",
-          client_info,
-          "percy-client/#{VERSION}",
-        ].compact.join(' ')
 
-        environment = [
-          environment_info,
-          "ruby/#{_ruby_version}",
-          current_ci,
-        ].compact.join('; ')
-
-        "#{client} (#{environment})"
-      end
 
       # @return [Hash] All commit data from the current commit. Might be empty if commit data could
       # not be found.
@@ -108,14 +94,6 @@ module Percy
         output = `git show --quiet #{commit_sha} --format="#{format}" 2> /dev/null`.strip
         return if $CHILD_STATUS.to_i != 0
         output
-      end
-
-      def self._ruby_version
-        "#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}"
-      end
-
-      def self._api_version
-        Config.new.api_url.match(/\w+$/).to_s
       end
 
       # The name of the current branch.

--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -26,8 +26,6 @@ module Percy
         return :gitlab if ENV['GITLAB_CI']
       end
 
-
-
       # @return [Hash] All commit data from the current commit. Might be empty if commit data could
       # not be found.
       def self.commit

--- a/spec/lib/percy/client/builds_spec.rb
+++ b/spec/lib/percy/client/builds_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Percy::Client::Builds, :vcr do
       expect(build['data']['relationships']['missing-resources']['data']).to be
       expect(build['data']['relationships']['missing-resources']['data'].length).to eq(1)
     end
+
     context 'with env vars configured' do
       before(:each) do
         ENV['PERCY_BRANCH'] = 'foo-branch'

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Percy::Client::Environment do
     }
     clear_env_vars
   end
+
   after(:each) do
     clear_env_vars
     ENV['TRAVIS_BUILD_ID'] = @original_env['TRAVIS_BUILD_ID']
@@ -106,48 +107,50 @@ RSpec.describe Percy::Client::Environment do
         expect(Percy::Client::Environment.current_ci).to be_nil
       end
     end
-    describe '#user_agent' do
-      it 'returns a user agent' do
-        user_agent = "Percy/v1 percy-client/#{Percy::Client::VERSION} "\
-                     "(ruby/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL})"
-        expect(Percy::Client::Environment.user_agent).to eq user_agent
-      end
-    end
+
     describe '#branch' do
       it 'returns master if not in a git repo' do
         expect(Percy::Client::Environment).to receive(:_raw_branch_output).and_return('')
         expect(Percy::Client::Environment.branch).to eq('master')
       end
+
       it 'reads from the current local repo' do
         expect(Percy::Client::Environment.branch).to_not be_empty
       end
+
       it 'can be overridden with PERCY_BRANCH' do
         ENV['PERCY_BRANCH'] = 'test-branch'
         expect(Percy::Client::Environment.branch).to eq('test-branch')
       end
     end
+
     describe '#target_branch' do
       it 'returns nil if unset' do
         expect(Percy::Client::Environment.target_branch).to be_nil
       end
+
       it 'can be set with PERCY_TARGET_BRANCH' do
         ENV['PERCY_TARGET_BRANCH'] = 'test-target-branch'
         expect(Percy::Client::Environment.target_branch).to eq('test-target-branch')
       end
     end
+
     describe '#_commit_sha' do
       it 'returns nil if no environment info can be found' do
         expect(Percy::Client::Environment._commit_sha).to be_nil
       end
+
       it 'can be overridden with PERCY_COMMIT' do
         ENV['PERCY_COMMIT'] = 'test-commit'
         expect(Percy::Client::Environment._commit_sha).to eq('test-commit')
       end
     end
+
     describe '#pull_request_number' do
       it 'returns nil if no CI environment' do
         expect(Percy::Client::Environment.pull_request_number).to be_nil
       end
+
       it 'can be overridden with PERCY_PULL_REQUEST' do
         ENV['PERCY_PULL_REQUEST'] = '123'
         ENV['TRAVIS_BUILD_ID'] = '1234'
@@ -155,18 +158,22 @@ RSpec.describe Percy::Client::Environment do
         expect(Percy::Client::Environment.pull_request_number).to eq('123')
       end
     end
+
     describe '#repo' do
       it 'returns the current local repo name' do
         expect(Percy::Client::Environment.repo).to eq('percy/percy-client')
       end
+
       it 'can be overridden with PERCY_PROJECT' do
         ENV['PERCY_PROJECT'] = 'percy/slug'
         expect(Percy::Client::Environment.repo).to eq('percy/slug')
       end
+
       it 'can be overridden with PERCY_REPO_SLUG (deprecated)' do
         ENV['PERCY_REPO_SLUG'] = 'percy/slug'
         expect(Percy::Client::Environment.repo).to eq('percy/slug')
       end
+
       it 'handles git ssh urls' do
         expect(Percy::Client::Environment).to receive(:_get_origin_url)
           .once.and_return('git@github.com:org-name/repo-name.git')
@@ -180,6 +187,7 @@ RSpec.describe Percy::Client::Environment do
           .once.and_return('git@custom-local-hostname:org-name/repo-name.org')
         expect(Percy::Client::Environment.repo).to eq('org-name/repo-name.org')
       end
+
       it 'handles git https urls' do
         expect(Percy::Client::Environment).to receive(:_get_origin_url)
           .once.and_return('https://github.com/org-name/repo-name.git')
@@ -193,6 +201,7 @@ RSpec.describe Percy::Client::Environment do
           .once.and_return("https://github.com/org-name/repo-name.org\n")
         expect(Percy::Client::Environment.repo).to eq('org-name/repo-name.org')
       end
+
       it 'errors if unable to parse local repo name' do
         expect(Percy::Client::Environment).to receive(:_get_origin_url).once.and_return('foo')
         expect { Percy::Client::Environment.repo }.to raise_error(
@@ -200,19 +209,23 @@ RSpec.describe Percy::Client::Environment do
         )
       end
     end
+
     describe '#parallel_nonce' do
       it 'returns nil' do
         expect(Percy::Client::Environment.parallel_nonce).to be_nil
       end
+
       it 'can be set with environment var' do
         ENV['PERCY_PARALLEL_NONCE'] = 'nonce'
         expect(Percy::Client::Environment.parallel_nonce).to eq('nonce')
       end
     end
+
     describe '#parallel_total_shards' do
       it 'returns nil' do
         expect(Percy::Client::Environment.parallel_nonce).to be_nil
       end
+
       it 'can be set with environment var' do
         ENV['PERCY_PARALLEL_TOTAL'] = '3'
         expect(Percy::Client::Environment.parallel_total_shards).to eq(3)
@@ -229,8 +242,6 @@ RSpec.describe Percy::Client::Environment do
   end
 
   context 'in Jenkins CI' do
-    it_behaves_like 'an environment user agent that includes CI', 'jenkins'
-
     before(:each) do
       ENV['JENKINS_URL'] = 'http://localhost:8080/'
       ENV['ghprbPullId'] = '123'
@@ -246,9 +257,8 @@ RSpec.describe Percy::Client::Environment do
       expect(Percy::Client::Environment.repo).to eq('percy/percy-client')
     end
   end
-  context 'in Travis CI' do
-    it_behaves_like 'an environment user agent that includes CI', 'travis'
 
+  context 'in Travis CI' do
     before(:each) do
       ENV['TRAVIS_BUILD_ID'] = '1234'
       ENV['TRAVIS_BUILD_NUMBER'] = 'build-number'
@@ -277,25 +287,27 @@ RSpec.describe Percy::Client::Environment do
         ENV['TRAVIS_PULL_REQUEST_BRANCH'] = 'travis-pr-branch'
         ENV['TRAVIS_PULL_REQUEST_SHA'] = 'travis-pr-head-commit-sha'
       end
+
       it 'has the correct properties' do
         expect(Percy::Client::Environment.branch).to eq('travis-pr-branch')
         expect(Percy::Client::Environment._commit_sha).to eq('travis-pr-head-commit-sha')
         expect(Percy::Client::Environment.pull_request_number).to eq('256')
       end
     end
+
     context 'parallel build' do
       before(:each) do
         ENV['CI_NODE_TOTAL'] = '3'
       end
+
       it 'has the correct properties' do
         expect(Percy::Client::Environment.parallel_nonce).to eq('build-number')
         expect(Percy::Client::Environment.parallel_total_shards).to eq(3)
       end
     end
   end
-  context 'in Circle CI' do
-    it_behaves_like 'an environment user agent that includes CI', 'circle'
 
+  context 'in Circle CI' do
     before(:each) do
       ENV['CIRCLECI'] = 'true'
       ENV['CIRCLE_BRANCH'] = 'circle-branch'
@@ -316,19 +328,20 @@ RSpec.describe Percy::Client::Environment do
       expect(Percy::Client::Environment.parallel_nonce).to eq('build-number')
       expect(Percy::Client::Environment.parallel_total_shards).to be_nil
     end
+
     context 'parallel build' do
       before(:each) do
         ENV['CIRCLE_NODE_TOTAL'] = '3'
       end
+
       it 'has the correct properties' do
         expect(Percy::Client::Environment.parallel_nonce).to eq('build-number')
         expect(Percy::Client::Environment.parallel_total_shards).to eq(3)
       end
     end
   end
-  context 'in Codeship' do
-    it_behaves_like 'an environment user agent that includes CI', 'codeship'
 
+  context 'in Codeship' do
     before(:each) do
       ENV['CI_NAME'] = 'codeship'
       ENV['CI_BRANCH'] = 'codeship-branch'
@@ -347,19 +360,20 @@ RSpec.describe Percy::Client::Environment do
       expect(Percy::Client::Environment.parallel_nonce).to eq('codeship-build-number')
       expect(Percy::Client::Environment.parallel_total_shards).to be_nil
     end
+
     context 'parallel build' do
       before(:each) do
         ENV['CI_NODE_TOTAL'] = '3'
       end
+
       it 'has the correct properties' do
         expect(Percy::Client::Environment.parallel_nonce).to eq('codeship-build-number')
         expect(Percy::Client::Environment.parallel_total_shards).to eq(3)
       end
     end
   end
-  context 'in Drone' do
-    it_behaves_like 'an environment user agent that includes CI', 'drone'
 
+  context 'in Drone' do
     before(:each) do
       ENV['DRONE'] = 'true'
       ENV['DRONE_COMMIT'] = 'drone-commit-sha'
@@ -375,9 +389,8 @@ RSpec.describe Percy::Client::Environment do
       expect(Percy::Client::Environment.repo).to eq('percy/percy-client')
     end
   end
-  context 'in Semaphore CI' do
-    it_behaves_like 'an environment user agent that includes CI', 'semaphore'
 
+  context 'in Semaphore CI' do
     before(:each) do
       ENV['SEMAPHORE'] = 'true'
       ENV['BRANCH_NAME'] = 'semaphore-branch'
@@ -397,19 +410,20 @@ RSpec.describe Percy::Client::Environment do
       expect(Percy::Client::Environment.parallel_nonce).to eq('semaphore-build-number')
       expect(Percy::Client::Environment.parallel_total_shards).to be_nil
     end
+
     context 'parallel build' do
       before(:each) do
         ENV['SEMAPHORE_THREAD_COUNT'] = '3'
       end
+
       it 'has the correct properties' do
         expect(Percy::Client::Environment.parallel_nonce).to eq('semaphore-build-number')
         expect(Percy::Client::Environment.parallel_total_shards).to eq(3)
       end
     end
   end
-  context 'in Buildkite' do
-    it_behaves_like 'an environment user agent that includes CI', 'buildkite'
 
+  context 'in Buildkite' do
     before(:each) do
       ENV['BUILDKITE'] = 'true'
       ENV['BUILDKITE_COMMIT'] = 'buildkite-commit-sha'
@@ -455,8 +469,6 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Gitlab CI' do
-    it_behaves_like 'an environment user agent that includes CI', 'gitlab'
-
     before(:each) do
       ENV['GITLAB_CI'] = 'yes'
       ENV['CI_BUILD_REF'] = 'gitlab-commit-sha'

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe Percy::Client::Environment do
         expect(Percy::Client::Environment.current_ci).to be_nil
       end
     end
+    describe '#user_agent' do
+      it 'returns a user agent' do
+        user_agent = "Percy/v1 percy-client/#{Percy::Client::VERSION} "\
+                     "(ruby/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL})"
+        expect(Percy::Client::Environment.user_agent).to eq user_agent
+      end
+    end
     describe '#branch' do
       it 'returns master if not in a git repo' do
         expect(Percy::Client::Environment).to receive(:_raw_branch_output).and_return('')
@@ -212,7 +219,18 @@ RSpec.describe Percy::Client::Environment do
       end
     end
   end
+
+  RSpec.shared_examples 'an environment user agent that includes CI' do |ci_name|
+    it 'returns a user_agent that includes CI name' do
+      user_agent = "Percy/v1 percy-client/#{Percy::Client::VERSION} "\
+                   "(ruby/#{RUBY_VERSION}p#{RUBY_PATCHLEVEL}; #{ci_name})"
+      expect(Percy::Client::Environment.user_agent).to eq user_agent
+    end
+  end
+
   context 'in Jenkins CI' do
+    it_behaves_like 'an environment user agent that includes CI', 'jenkins'
+
     before(:each) do
       ENV['JENKINS_URL'] = 'http://localhost:8080/'
       ENV['ghprbPullId'] = '123'
@@ -229,6 +247,8 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Travis CI' do
+    it_behaves_like 'an environment user agent that includes CI', 'travis'
+
     before(:each) do
       ENV['TRAVIS_BUILD_ID'] = '1234'
       ENV['TRAVIS_BUILD_NUMBER'] = 'build-number'
@@ -250,6 +270,7 @@ RSpec.describe Percy::Client::Environment do
       expect(Percy::Client::Environment.parallel_nonce).to eq('build-number')
       expect(Percy::Client::Environment.parallel_total_shards).to be_nil
     end
+
     context 'Pull Request build' do
       before(:each) do
         ENV['TRAVIS_PULL_REQUEST'] = '256'
@@ -273,6 +294,8 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Circle CI' do
+    it_behaves_like 'an environment user agent that includes CI', 'circle'
+
     before(:each) do
       ENV['CIRCLECI'] = 'true'
       ENV['CIRCLE_BRANCH'] = 'circle-branch'
@@ -304,6 +327,8 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Codeship' do
+    it_behaves_like 'an environment user agent that includes CI', 'codeship'
+
     before(:each) do
       ENV['CI_NAME'] = 'codeship'
       ENV['CI_BRANCH'] = 'codeship-branch'
@@ -333,6 +358,8 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Drone' do
+    it_behaves_like 'an environment user agent that includes CI', 'drone'
+
     before(:each) do
       ENV['DRONE'] = 'true'
       ENV['DRONE_COMMIT'] = 'drone-commit-sha'
@@ -349,6 +376,8 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Semaphore CI' do
+    it_behaves_like 'an environment user agent that includes CI', 'semaphore'
+
     before(:each) do
       ENV['SEMAPHORE'] = 'true'
       ENV['BRANCH_NAME'] = 'semaphore-branch'
@@ -379,6 +408,8 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Buildkite' do
+    it_behaves_like 'an environment user agent that includes CI', 'buildkite'
+
     before(:each) do
       ENV['BUILDKITE'] = 'true'
       ENV['BUILDKITE_COMMIT'] = 'buildkite-commit-sha'
@@ -424,6 +455,8 @@ RSpec.describe Percy::Client::Environment do
     end
   end
   context 'in Gitlab CI' do
+    it_behaves_like 'an environment user agent that includes CI', 'gitlab'
+
     before(:each) do
       ENV['GITLAB_CI'] = 'yes'
       ENV['CI_BUILD_REF'] = 'gitlab-commit-sha'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,4 +28,10 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.after(:each) do |_example|
+    # After each run, clear the memoized `_user_agent` property to avoid polluting
+    # other tests with the incorrect values.
+    Percy.client._reset_user_agent
+  end
 end

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -5,6 +5,10 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
 
+  # Uncomment this to get VCR logger debugging.
+  # Run: `rspec spec vcr.log` to get debugging output to vcr.log
+  # c.debug_logger = File.open(ARGV[1], 'w')
+
   c.default_cassette_options = {
     record: ENV['RECORD'] ? :new_episodes : :none,
   }


### PR DESCRIPTION
This PR includes:

* New `client_info` and `environment_info` options to `Percy::Client`. This allows a higher level client to pass down information about itself to this lower level client for inclusion in the `User-Agent` header, which is sent to the API.
   * `client_info` would be something like `percy-capybara/3.1.0`
   * `environment_info ` would be something like `Rails/4.2.1`
* Construction of a full user agent. This is sent along as a header to the Percy API with every `GET` and `POST` request.
   * Sample user agent: `Percy/v1 percy-capybara/3.1.0 percy-client/1.1.0 (Rails/4.2.1; ruby/2.2.6p396; buildkite)`
* A refactoring of the `connection` specs to reduce duplication by making use of `shared_examples_for` and `subject`.
* Whitespace updates to areas of the codebase I touched based on an internal discussion

In theory this is done, but I'd like to get `percy-capybara` up and running first to use this before merging.