### PR TITLE
Fix "invalid byte sequence in US-ASCII" when no LANG is set.

### DIFF
--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -31,6 +31,7 @@ module Percy
       def self.commit
         output = _raw_commit_output(_commit_sha) if _commit_sha
         output = _raw_commit_output('HEAD') unless output
+        output = output.force_encoding('UTF-8') if output && output.encoding.to_s == 'US-ASCII'
 
         # Use the specified SHA or, if not given, the parsed SHA at HEAD.
         commit_sha = _commit_sha || output && output.match(/COMMIT_SHA:(.*)/)[1]

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -524,6 +524,15 @@ RSpec.describe Percy::Client::Environment do
         expect(commit[:committer_name]).to be_nil
         expect(commit[:message]).to be_nil
       end
+      it 'handles unicode characters in environment where LANG is not set' do
+        output = "COMMIT_SHA:\nAUTHOR_NAME:Spêcìal Ñàme\nAUTHOR_EMAIL:\nCOMMITTER_NAME:\n" \
+          "COMMITTER_EMAIL:\nCOMMITTED_DATE:\nCOMMIT_MESSAGE:".force_encoding('US-ASCII')
+        expect(output.encoding.to_s).to eq('US-ASCII')
+        expect(Percy::Client::Environment).to receive(:_raw_commit_output).once.and_return(output)
+
+        commit = Percy::Client::Environment.commit
+        expect(commit[:author_name]).to eq('Spêcìal Ñàme')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #19 
