### PR TITLE
Reverse middleware to prevent Faraday warning.

### DIFF
--- a/lib/percy/client/connection.rb
+++ b/lib/percy/client/connection.rb
@@ -62,8 +62,8 @@ module Percy
         @connection = Faraday.new(url: base_url) do |faraday|
           faraday.request :token_auth, config.access_token if config.access_token
 
-          faraday.use Percy::Client::Connection::NoCookiesHTTPClientAdapter
           faraday.use Percy::Client::Connection::NiceErrorMiddleware
+          faraday.use Percy::Client::Connection::NoCookiesHTTPClientAdapter
         end
 
         @connection

--- a/spec/lib/percy/client/connection_spec.rb
+++ b/spec/lib/percy/client/connection_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Percy::Client::Connection do
   let(:ci_name) { 'buildkite' }
   let(:uri) { "#{Percy.config.api_url}/test" }
 
-  describe '#connection' do
-    it 'disables cookies on faraday httpclient adapter' do
-      expect(Percy.client.connection.builder.app.client.cookie_manager).to be_nil
-    end
-  end
-
   shared_examples_for 'a connection that sets headers with HTTP method' do |http_method|
     it 'sets headers' do
       stub_request(http_method, uri)


### PR DESCRIPTION
Fixes https://github.com/percy/percy-capybara/issues/45

Have tested this works, and does not create logging noise when creating Favstar builds.