### PR TITLE
If branch can't be detected, use default-branch instead of master

### DIFF
--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -30,7 +30,8 @@ module Percy
       # not be found.
       def self.commit
         output = _raw_commit_output(_commit_sha) if _commit_sha
-        output ||= _raw_commit_output('HEAD')
+        output = _raw_commit_output('HEAD') unless output
+        return { branch: branch } unless output && output != ""
         output = output.force_encoding('UTF-8') if output && output.encoding.to_s == 'US-ASCII'
 
         # Use the specified SHA or, if not given, the parsed SHA at HEAD.
@@ -129,8 +130,8 @@ module Percy
         end
 
         if result == ''
-          STDERR.puts '[percy] Warning: not in a git repo, setting PERCY_BRANCH to "master".'
-          result = 'master'
+          STDERR.puts '[percy] Warning: not in a git repo, setting PERCY_BRANCH to "unknown-branch".'
+          result = 'unknown-branch'
         end
         result
       end

--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -1,6 +1,8 @@
 module Percy
   class Client
     module Environment
+      BRANCH_FALLBACK = nil
+
       GIT_FORMAT_LINES = [
         'COMMIT_SHA:%H',
         'AUTHOR_NAME:%an',
@@ -130,8 +132,8 @@ module Percy
         end
 
         if result == ''
-          STDERR.puts '[percy] Warning: not in a git repo, setting PERCY_BRANCH to "unknown-branch".'
-          result = 'unknown-branch'
+          STDERR.puts '[percy] Warning: not in a git repo, setting PERCY_BRANCH to fallback.'
+          result = BRANCH_FALLBACK
         end
         result
       end

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Percy::Client::Environment do
     describe '#branch' do
       it 'returns master if not in a git repo' do
         expect(Percy::Client::Environment).to receive(:_raw_branch_output).and_return('')
-        expect(Percy::Client::Environment.branch).to eq('unknown-branch')
+        expect(Percy::Client::Environment.branch).to eq(Percy::Client::Environment::BRANCH_FALLBACK)
       end
 
       it 'reads from the current local repo' do
@@ -521,7 +521,7 @@ RSpec.describe Percy::Client::Environment do
         expect(Percy::Client::Environment).to receive(:_raw_branch_output).and_return('')
 
         commit = Percy::Client::Environment.commit
-        expect(commit[:branch]).to eq('unknown-branch')
+        expect(commit[:branch]).to eq(Percy::Client::Environment::BRANCH_FALLBACK)
         expect(commit[:sha]).to be_nil
 
         expect(commit[:author_email]).to be_nil

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Percy::Client::Environment do
     describe '#branch' do
       it 'returns master if not in a git repo' do
         expect(Percy::Client::Environment).to receive(:_raw_branch_output).and_return('')
-        expect(Percy::Client::Environment.branch).to eq('master')
+        expect(Percy::Client::Environment.branch).to eq('unknown-branch')
       end
 
       it 'reads from the current local repo' do
@@ -517,10 +517,11 @@ RSpec.describe Percy::Client::Environment do
       end
 
       it 'returns only branch if commit data cannot be found' do
-        expect(Percy::Client::Environment).to receive(:_raw_commit_output).once.and_return(nil)
+        expect(Percy::Client::Environment).to receive(:_raw_commit_output).and_return(nil)
+        expect(Percy::Client::Environment).to receive(:_raw_branch_output).and_return('')
 
         commit = Percy::Client::Environment.commit
-        expect(commit[:branch]).to be
+        expect(commit[:branch]).to eq('unknown-branch')
         expect(commit[:sha]).to be_nil
 
         expect(commit[:author_email]).to be_nil


### PR DESCRIPTION
Also fixes scenario when not in a git folder, or there's no commits (git show returns '').

Addresses:
* https://app.clubhouse.io/percy/story/1562/use-unknown-branch-instead-of-master-in-all-sdks
* https://app.clubhouse.io/percy/story/1648/ruby-client-via-static-website-fails-if-in-a-folder-that-isn-t-part-of-a-git-repo-or-has-no-commits

Should not be published until percy-api is updated to handle nil branches.
 
Does not address a handling a local branch differently if the branch is correctly read.