### PR TITLE
fix: Update CircleCI parallel nonce

### DIFF
--- a/lib/percy/client/environment.rb
+++ b/lib/percy/client/environment.rb
@@ -204,7 +204,7 @@ module Percy
         when :travis
           ENV['TRAVIS_BUILD_NUMBER']
         when :circle
-          ENV['CIRCLE_WORKFLOW_WORKSPACE_ID'] || ENV['CIRCLE_BUILD_NUM']
+          ENV['CIRCLE_WORKFLOW_ID'] || ENV['CIRCLE_BUILD_NUM']
         when :jenkins
           ENV['BUILD_NUMBER']
         when :codeship

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Percy::Client::Environment do
     ENV['CIRCLE_SHA1'] = nil
     ENV['CIRCLE_BRANCH'] = nil
     ENV['CIRCLE_BUILD_NUM'] = nil
-    ENV['CIRCLE_WORKFLOW_WORKSPACE_ID'] = nil
+    ENV['CIRCLE_WORKFLOW_ID'] = nil
     ENV['CI_PULL_REQUESTS'] = nil
 
     # Unset Codeship vars.

--- a/spec/lib/percy/client/environment_spec.rb
+++ b/spec/lib/percy/client/environment_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Percy::Client::Environment do
 
     context 'in Circle 2.0' do
       before(:each) do
-        ENV['CIRCLE_WORKFLOW_WORKSPACE_ID'] = 'circle-workflow-workspace-id'
+        ENV['CIRCLE_WORKFLOW_ID'] = 'circle-workflow-workspace-id'
       end
 
       it 'has the correct properties' do


### PR DESCRIPTION
## What is this?

This updates the parallel nonce for CircleCI to an env var that also changes for rebuilt workflows (otherwise rebuilds fail with Percy 409s)

See https://github.com/percy/percy-js/pull/148 for the percy-js equivalent 