### PR TITLE
Post stacktrace with snapshots

### DIFF
--- a/lib/percy/client/snapshots.rb
+++ b/lib/percy/client/snapshots.rb
@@ -8,6 +8,7 @@ module Percy
         end
 
         widths = options[:widths] || config.default_widths
+        stacktrace = options[:stacktrace] || caller.reject { |line| line.start_with? File.expand_path("../../..", __FILE__) }
         data = {
           'data' => {
             'type' => 'snapshots',
@@ -16,6 +17,7 @@ module Percy
               'enable-javascript' => options[:enable_javascript],
               'minimum-height' => options[:minimum_height],
               'widths' => widths,
+              'stacktrace' => stacktrace,
             },
             'relationships' => {
               'resources' => {

--- a/spec/lib/percy/client/snapshots_spec.rb
+++ b/spec/lib/percy/client/snapshots_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
               'enable-javascript' => true,
               'minimum-height' => nil,
               'widths' => Percy.config.default_widths,
+              'stacktrace' => start_with(start_with(__FILE__ + ":")),
             },
             'relationships' => {
               'resources' => {
@@ -81,6 +82,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
               'enable-javascript' => nil,
               'minimum-height' => 700,
               'widths' => [320, 1280],
+              'stacktrace' => ['somewhere_else.rb:32'],
             },
             'relationships' => {
               'resources' => {
@@ -116,6 +118,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
         name: 'homepage',
         widths: [320, 1280],
         minimum_height: 700,
+        stacktrace: ['somewhere_else.rb:32'],
       )
 
       expect(snapshot['data']).to be


### PR DESCRIPTION
Imagine you're looking at a change set, but you don't understand why it's changed, and so you want to replicate the application state to see the interface and investigate. But you use lovely descriptive snapshot names, and these are generated in your codebase, so aren't an easy grep away.

What if you could jump to the source code location which generated the snapshot straight from the Percy dashboard?

![Percy dashboard mockup showing snapshot with diff and link to source code location](https://user-images.githubusercontent.com/14028/89700699-b63ae180-d973-11ea-8beb-a581c88cf1dd.gif)

This code can be used to identify the line in a test suite which generated a snapshot making for easier identification and diagnosis. This implementation is pretty rough, but is good enough for a proof of concept.