### PR TITLE
[PPLT-1821] Add support for scope_selector to be passed to snapshot creation

### DIFF
--- a/lib/percy/client/snapshots.rb
+++ b/lib/percy/client/snapshots.rb
@@ -14,6 +14,7 @@ module Percy
             'attributes' => {
               'name' => options[:name],
               'enable-javascript' => options[:enable_javascript],
+              'scope' => options[:scope_selector],
               'minimum-height' => options[:minimum_height],
               'widths' => widths,
             },

--- a/lib/percy/client/version.rb
+++ b/lib/percy/client/version.rb
@@ -1,5 +1,5 @@
 module Percy
   class Client
-    VERSION = '2.0.6'.freeze
+    VERSION = '2.0.7'.freeze
   end
 end

--- a/spec/lib/percy/client/snapshots_spec.rb
+++ b/spec/lib/percy/client/snapshots_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
             'attributes' => {
               'name' => 'homepage',
               'enable-javascript' => true,
+              'scope' => 'body',
               'minimum-height' => nil,
               'widths' => Percy.config.default_widths,
             },
@@ -55,6 +56,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
         resources,
         name: 'homepage',
         enable_javascript: true,
+        scope_selector: 'body',
       )
 
       expect(snapshot['data']).to be
@@ -79,6 +81,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
             'attributes' => {
               'name' => 'homepage',
               'enable-javascript' => nil,
+              'scope' => nil,
               'minimum-height' => 700,
               'widths' => [320, 1280],
             },


### PR DESCRIPTION
**Context -**
- Added support to pass `scope` for snapshot creation API via percy-client
- Verified that the parameter needs to be named as `scope` as per the percy-api endpoint [here](https://github.com/percy/percy-api/blob/master/app/controllers/api/v1/snapshots_controller.rb#L79).