### PR TITLE
feat: add support for root_for_width

### DIFF
--- a/lib/percy/client/resources.rb
+++ b/lib/percy/client/resources.rb
@@ -9,6 +9,7 @@ module Percy
       attr_accessor :sha
       attr_accessor :resource_url
       attr_accessor :is_root
+      attr_accessor :root_for_width
       attr_accessor :mimetype
       attr_accessor :content
       attr_accessor :path
@@ -23,6 +24,7 @@ module Percy
         @content = options[:content]
 
         @is_root = options[:is_root]
+        @root_for_width = options[:root_for_width]
         @mimetype = options[:mimetype]
 
         # For optional convenience of temporarily storing the local content and path with this
@@ -39,6 +41,7 @@ module Percy
             'resource-url' => Addressable::URI.escape(resource_url),
             'mimetype' => mimetype,
             'is-root' => is_root,
+            'for-widths' => [root_for_width],
           },
         }
       end
@@ -60,7 +63,7 @@ module Percy
 
       def inspect
         content_msg = content.nil? ? '' : "content.length: #{content.length}"
-        "<Resource #{sha} #{resource_url} is_root:#{!!is_root} #{mimetype} #{content_msg}>"
+        "<Resource #{sha} #{resource_url} root_for_width:#{root_for_width} is_root:#{!!is_root} #{mimetype} #{content_msg}>"
       end
       alias to_s inspect
     end

--- a/lib/percy/client/version.rb
+++ b/lib/percy/client/version.rb
@@ -1,5 +1,5 @@
 module Percy
   class Client
-    VERSION = '2.0.7'.freeze
+    VERSION = '2.0.8'.freeze
   end
 end

--- a/spec/lib/percy/client/resources_spec.rb
+++ b/spec/lib/percy/client/resources_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Percy::Client::Resource do
         'resource-url' => '/foo.html',
         'mimetype' => nil,
         'is-root' => nil,
+        'for-widths' => [nil],
       },
     )
   end
@@ -49,6 +50,7 @@ RSpec.describe Percy::Client::Resource do
         'resource-url' => '/foo%20new.html',
         'mimetype' => 'text/html',
         'is-root' => true,
+        'for-widths' => [nil],
       },
     )
   end

--- a/spec/lib/percy/client/snapshots_spec.rb
+++ b/spec/lib/percy/client/snapshots_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
                       'resource-url' => '/foo/test.html',
                       'mimetype' => nil,
                       'is-root' => true,
+                      'for-widths' => [nil],
                     },
                   },
                   {
@@ -42,6 +43,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
                       'resource-url' => '/css/test.css',
                       'mimetype' => nil,
                       'is-root' => nil,
+                      'for-widths' => [nil],
                     },
                   },
                 ],
@@ -95,6 +97,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
                       'resource-url' => '/foo/test.html',
                       'mimetype' => nil,
                       'is-root' => true,
+                      'for-widths' => [nil],
                     },
                   },
                   {
@@ -104,6 +107,7 @@ RSpec.describe Percy::Client::Snapshots, :vcr do
                       'resource-url' => '/css/test.css',
                       'mimetype' => nil,
                       'is-root' => nil,
+                      'for-widths' => [nil],
                     },
                   },
                 ],


### PR DESCRIPTION
**Context -**
- Since the addition of `defer-uploads` we can have multiple root resources (html) for single snapshot
- But, we need to provide extra widths property for the same to take effect
- Hence, added `for-widths` property in percy-client to support multiple root-htmls for different widths
