### PR TITLE
Pplt 9999 downgrade faraday

### DIFF
--- a/lib/percy/client/version.rb
+++ b/lib/percy/client/version.rb
@@ -1,5 +1,5 @@
 module Percy
   class Client
-    VERSION = '2.1.0'.freeze
+    VERSION = '2.1.1'.freeze
   end
 end

--- a/percy-client.gemspec
+++ b/percy-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '0.17.3'
+  spec.add_dependency 'faraday', '0.15.4'
   spec.add_dependency 'excon', '0.105.0'
   spec.add_dependency 'addressable'
 


### PR DESCRIPTION
We need to downgrade this as one of the other dependencies is pinned to this version which we need to update in future